### PR TITLE
Ensure Dates Always Have A Valid 'dec_num' Value

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -1391,12 +1391,12 @@ class Cursor:
                     buf_size = self.connection.type_size_dic[SQL_TYPE_DATE][0]
                     
                     ParameterBuffer = create_buffer(buf_size)
-                    dec_num = self.connection.type_size_dic[SQL_TYPE_DATE][1]
+                    dec_num = self.connection.type_size_dic[SQL_TYPE_DATE][1] or 0
                     
                 else:
                     # SQL Sever <2008 doesn't have a DATE type.
                     sql_type = SQL_TYPE_TIMESTAMP 
-                    buf_size = 10                    
+                    buf_size, dec_num = 10, 0                    
                     ParameterBuffer = create_buffer(buf_size)
                     
     


### PR DESCRIPTION
Ensure that if the local driver returns `None` when the connection's `type_size_dic` is queried for the proper value(s) of `dec_num` for `date` values ~~because it was written by an **unhinged madman**~~ *for some reason* that a valid and correct integer value is still supplied to `SQLBindParameter`.

May be an extreme edge case, but I *did* personally experience it and have the [Sentry](https://sentry.io/) logs if they'd be helpful.