### PR TITLE
Automated Release Build and Publishing

### DIFF
--- a/.github/scripts/inject-version.sh
+++ b/.github/scripts/inject-version.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Put actual version number into the sources, in place of "0.0.0a0".
+set -e
+
+version=${1:-$GITHUB_REF_NAME}
+
+# remove leading "v", if present
+version=${version#v}
+
+if [[ -z $version ]]; then
+    >&2 echo "Error: No version provided."
+    exit 1
+fi
+
+# sanity check - this doesn't cover everything in PEP 440
+# https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
+if [[ ! $version =~ ^[-.0-9abrcdevpost]+$ ]]; then
+    >&2 echo "Error: Invalid character in version '$version'."
+    exit 1
+fi
+
+echo "Setting version to '$version'."
+sed -i -e "/version/s/0\.0\.0a0/$version/" setup.py pypyodbc.py

--- a/.github/scripts/publish-dist-artifacts.sh
+++ b/.github/scripts/publish-dist-artifacts.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Publish distribution artifacts to PyPI or Test PyPI, if applicable.
+# The publishing target is determined from the version number.
+# Credentials are expected to be configured in the ~/.pypirc file.
+set -e
+
+version=${1:-$GITHUB_REF_NAME}
+
+# remove leading "v", if present
+version=${version#v}
+
+if [[ -z $version ]]; then
+    >&2 echo "Error: No version provided."
+    exit 1
+fi
+
+case $version in
+    *dev*)
+        echo "No publishing. (development release)"
+        exit 0
+        ;;
+
+    *[ab]*)
+        echo "Publishing to Test PyPI. (alpha or beta release)"
+        repository=testpypi
+        ;;
+
+    *)
+        echo "Publishing to PyPI proper."
+        repository=pypi
+        ;;
+esac
+
+
+# https://packaging.python.org/en/latest/tutorials/packaging-projects/#uploading-the-distribution-archives
+
+echo -e "\nInstalling latest twine..."
+python3 -m pip install --upgrade twine
+
+echo -e "\nUploading to $repository..."
+python3 -m twine upload --non-interactive --disable-progress-bar \
+        --repository "$repository" --skip-existing dist/*$version*
+
+echo -e "\nDone."

--- a/.github/scripts/pypirc-template
+++ b/.github/scripts/pypirc-template
@@ -1,0 +1,9 @@
+# https://packaging.python.org/en/latest/specifications/pypirc/
+
+[testpypi]
+username = __token__
+password = @testpypi-upload-token@
+
+[pypi]
+username = __token__
+password = @pypi-upload-token@

--- a/.github/scripts/upload-dist-artifacts.sh
+++ b/.github/scripts/upload-dist-artifacts.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Upload distribution artifacts to a release.
+set -e
+
+token=${1:-$GITHUB_TOKEN}
+
+if [[ -z $token ]]; then
+    >&2 echo "Error: GITHUB_TOKEN not provided as argument or env var."
+    exit 1
+fi
+if [[ -z $GITHUB_EVENT_PATH ]]; then
+    >&2 echo "Error: GITHUB_EVENT_PATH is not set."
+    exit 1
+fi
+
+upload_url=$( jq -r '.release.upload_url' <"$GITHUB_EVENT_PATH" )
+
+# get rid of the {?name,label} part of the URL
+# https://uploads.github.com/.../assets{?name,label}   becomes
+# https://uploads.github.com/.../assets
+_brace='{'
+upload_url=${upload_url%$_brace*}
+
+if [[ -z $upload_url ]]; then
+    >&2 echo "Error: Cannot determine upload URL from GITHUB_EVENT_PATH."
+    exit 1
+fi
+
+for file in dist/* ; do
+    echo "Uploading $file..."
+
+    # URL-encode with jq, see https://stackoverflow.com/a/34407620
+    name=$(jq -rn --arg x $(basename $file) '$x|@uri')
+    label=$name
+
+    if [[ $file == *.tar.gz ]]; then
+        # https://superuser.com/a/960710
+        content_type=application/gzip
+    elif [[ $file == *.whl ]]; then
+        # https://stackoverflow.com/a/58543864
+        content_type=application/x-pywheel+zip
+    else
+        content_type=application/binary
+    fi
+
+    # https://docs.github.com/en/rest/reference/releases#upload-a-release-asset
+    curl --fail -sS \
+         --header "Accept: application/vnd.github.v3+json" \
+         --header "Authorization: Bearer $token" \
+         --header "Content-Type: $content_type" \
+         --data-binary "@$file" \
+         "$upload_url?name=$name&label=$label"
+
+    echo -e "\nDone.\n"
+done

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,0 +1,40 @@
+name: Build and Publish Python Package
+
+on:
+  release:
+    types: [published]
+
+# see also...
+# https://github.com/jugmac00/will-it-build/blob/main/action.yml
+# https://packaging.python.org/en/latest/tutorials/packaging-projects/#generating-distribution-archives
+# https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#packaging-your-project
+
+# Intentionally not using setup-python here,
+# instead relying on the pre-installed python3.
+# https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v2
+    - run: .github/scripts/inject-version.sh
+    - run: python3 -m pip install --upgrade build
+    - run: python3 -m build
+    - run: ls -AlF dist/
+
+    - name: Upload artifacts to the release
+      run: |
+        if [[ $GITHUB_EVENT_NAME == release ]]; then
+          .github/scripts/upload-dist-artifacts.sh ${{ secrets.GITHUB_TOKEN }}
+        fi
+
+    - name: Setup credentials for publishing
+      run: |
+        sed <.github/scripts/pypirc-template >$HOME/.pypirc \
+          -e 's;@testpypi-upload-token@;${{ secrets.TESTPYPI_UPLOAD_TOKEN }};' \
+          -e 's;@pypi-upload-token@;${{ secrets.PYPI_UPLOAD_TOKEN }};'
+    - name: Publish artifacts to a repository
+      run: .github/scripts/publish-dist-artifacts.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*~
+
+# created by python -m build
+dist/
+__pycache__/
+*.egg-info/

--- a/accesstests.py
+++ b/accesstests.py
@@ -296,9 +296,6 @@ class AccessTestCase(unittest.TestCase):
         self.assertEquals(row[0], "1")
         self.assertEquals(row[-1], "1")
 
-    def test_version(self):
-        self.assertEquals(3, len(pypyodbc.version.split('.'))) # 1.3.1 etc.
-
     #
     # date, time, datetime
     #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+# https://packaging.python.org/en/latest/tutorials/packaging-projects/#creating-pyproject-toml
+
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -26,7 +26,7 @@ pooling = True
 apilevel = '2.0'
 paramstyle = 'qmark'
 threadsafety = 1
-version = '1.3.6'
+version = '0.0.0a0' # actual version injected at release build time
 
 DEBUG = 0
 # Comment out all "if DEBUG:" statements like below for production

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,9 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import pypyodbc
-
 setup(
     name='pypyodbc',
-    version=pypyodbc.version,
+    version='0.0.0a0', # actual version injected at release build time
     description='A Pure Python ctypes ODBC module',
     author='jiangwen365',
     author_email='jiangwen365@gmail.com',

--- a/sqlservertests.py
+++ b/sqlservertests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 usage = """\
 usage: %prog [options] connection_string
@@ -533,9 +533,6 @@ class SqlServerTestCase(unittest.TestCase):
         row = self.cursor.execute("select * from t1").fetchone()
         self.assertEquals(row[0], "1")
         self.assertEquals(row[-1], "1")
-
-    def test_version(self):
-        self.assertEquals(3, len(pypyodbc.version.split('.'))) # 1.3.1 etc.
 
     #
     # date, time, datetime


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow. When you **publish** a new GitHub release, this workflow...
1. takes the version number from the release tag, for example "v1.4.0dev1".
2. injects that version into `setup.py` and `pypyodbc.py`.
3. builds a source archive and a py3 wheel, which is cross-platform.
   - The version number is part of the file names.
4. uploads both artifacts to the GitHub release.
5. depending on the version number...
   1. If the version contains "dev", as in the example above, nothing further happens.
      - For [developmental releases](https://www.python.org/dev/peps/pep-0440/#developmental-releases).
      - Example [release](https://github.com/rolweber/pypyodbc/releases/tag/v0.1.3dev8) and [build log](https://github.com/rolweber/pypyodbc/runs/4761401505?check_suite_focus=true).
   2. If the version contains "a" or "b", for example v1.4.0a2, both artifacts are published to Test PyPI.
      - For alpha and beta [pre-releases](https://www.python.org/dev/peps/pep-0440/#pre-releases).
      - Example [release](https://github.com/rolweber/pypyodbc/releases/tag/v0.1.3a8) and [build log](https://github.com/rolweber/pypyodbc/runs/4761478207?check_suite_focus=true).
   3. Otherwise, both artifacts are published to PyPI proper.
      - For rc and [final releases](https://www.python.org/dev/peps/pep-0440/#final-releases).
      - Example [release](https://github.com/rolweber/pypyodbc/releases/tag/v0.1.3rc8) and [build log](https://github.com/rolweber/pypyodbc/runs/4761543158?check_suite_focus=true).
        Upload to PyPI failed intentionally, as I don't have permission to yank or delete a release.
        But the upload script was tested with a dummy project against PyPI, too.

The major change to the codebase is that I've removed the "next" version number from `pypyodbc.py` and instead put a placeholder there, and into `setup.py`. That placeholder is searched and replaced by the version injection script. @braian87b if you move the versions to another file, for example from `setup.py` to `setup.cfg`, you'll have to update `.github/scripts/inject-version.sh` accordingly. The line with the `sed` command at the end.
I had to remove the import of pypyodbc from `setup.py` to make the build work, and instead duplicated the version placeholder. On import, pypyodbc tries to load libodbc. But that library may not available in the build environment, where `setup.py` is evaluated. With the version number being injected automatically, there's no concern about differing version numbers in two places anymore.
I removed the `test_version` functions from two files. It would only test the placeholder, but not the actual version that's injected at build time.

There are some moving pieces in the workflow. It uses GitHub's latest Ubuntu image, where the `python3` version may change. It installs the latest version of `build` for building the packages, and of `twine` for uploading to (test) PyPI. If there is a new release after a longer break, I recommend to first make a developmental release (for testing the build step), then an alpha release (for testing the publishing step).