### PR TITLE
Fix discovery of libodbc on macOS with Apple Silicon

### DIFF
--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -435,13 +435,16 @@ else:
             # we try finding it manually from where libodbc.so usually appears
             if sys.platform == 'darwin':
                 lib_paths = (
-                    "/usr/lib/libodbc.dylib", "/usr/local/lib/libodbc.dylib",
+                    "/usr/lib/libodbc.dylib",
+                    "/usr/local/lib/libodbc.dylib",
                     "/opt/homebrew/lib/libodbc.dylib"
                 )
             else:
                 lib_paths = (
-                    "/usr/lib/libodbc.so", "/usr/lib/i386-linux-gnu/libodbc.so",
-                    "/usr/lib/x86_64-linux-gnu/libodbc.so", "/usr/lib/libiodbc.dylib"
+                    "/usr/lib/libodbc.so",
+                    "/usr/lib/i386-linux-gnu/libodbc.so",
+                    "/usr/lib/x86_64-linux-gnu/libodbc.so",
+                    "/usr/lib/libiodbc.dylib"
                 )
             lib_paths = [path for path in lib_paths if os.path.exists(path)]
             if len(lib_paths) == 0 :

--- a/pypyodbc.py
+++ b/pypyodbc.py
@@ -433,7 +433,16 @@ else:
         if library is None:
             # If find_library still can not find the library
             # we try finding it manually from where libodbc.so usually appears
-            lib_paths = ("/usr/lib/libodbc.so","/usr/lib/i386-linux-gnu/libodbc.so","/usr/lib/x86_64-linux-gnu/libodbc.so","/usr/lib/libiodbc.dylib")
+            if sys.platform == 'darwin':
+                lib_paths = (
+                    "/usr/lib/libodbc.dylib", "/usr/local/lib/libodbc.dylib",
+                    "/opt/homebrew/lib/libodbc.dylib"
+                )
+            else:
+                lib_paths = (
+                    "/usr/lib/libodbc.so", "/usr/lib/i386-linux-gnu/libodbc.so",
+                    "/usr/lib/x86_64-linux-gnu/libodbc.so", "/usr/lib/libiodbc.dylib"
+                )
             lib_paths = [path for path in lib_paths if os.path.exists(path)]
             if len(lib_paths) == 0 :
                 raise OdbcNoLibrary('ODBC Library is not found. Is LD_LIBRARY_PATH set?')


### PR DESCRIPTION
On Apple Silicon homebew prefix is no longer `/usr/local` but `/opt/homebrew` this causes pypyodbc to fail when loaded.

Fixes #11