### PR TITLE
Add basic support to run unittests in GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+# GitHub action to run on every Pull Request.
+
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
+  workflow_dispatch:
+    # Allows us to manually trigger the workflow.
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install OS dependencies
+      run: sudo apt install unixodbc
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install Python dependencies
+      run: |
+        pip install -U pip
+        pip install -r dev-requirements.txt
+    - name: Unittests
+      run: green -p 'test_*.py'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ 'main' ]
   pull_request:
     branches: [ '**' ]
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,154 @@
+# Based off: https://raw.githubusercontent.com/github/gitignore/master/Python.gitignore
+
+# Editors
+.vscode/
+.idea/
+
+# macOS
+.DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Also check out the [Wiki](https://github.com/pypyodbc/pypyodbc/wiki) and [Versio
 Features
 --------
 
-  * One pure Python script, runs on CPython / IronPython / PyPy , Python 3.3 / 2.4 / 2.5 / 2.6 / 2.7 , Win / Linux , 32 / 64 bit, now also seems to work on Mac with little effor: [How to use pypyodbc on MacOS OSX](https://github.com/pypyodbc/pypyodbc/wiki/How-to-use-pypyodbc-on-MacOS-OSX)
+  * One pure Python script, runs on CPython / IronPython / PyPy , Python 3.3 / 2.4 / 2.5 / 2.6 / 2.7 , Win / Linux / macOS, 32 / 64 bit: [How to use pypyodbc on MacOS OSX](https://github.com/pypyodbc/pypyodbc/wiki/How-to-use-pypyodbc-on-MacOS-OSX)
   * Almost totally same usage as pyodbc (can be seen as a re-implementation of pyodbc in pure Python via ctypes)
   * Simple - the whole module is implemented in a single python script with less than 3000 lines
   * [Built-in Access MDB file creation and compression functions](https://github.com/pypyodbc/pypyodbc/wiki/Access-MDB-support) on Windows 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,7 @@
+# Required packages in order to develop and test pypyodbc
+
+coverage
+green >= 3.4.1
+mypy
+pylint
+wheel

--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,25 @@ import pypyodbc
 setup(
     name='pypyodbc',
     version=pypyodbc.version,
-    description='A Pure Python ctypes ODBC module',
+    description='A Pure Python ctypes ODBC module.',
     author='jiangwen365',
     author_email='jiangwen365@gmail.com',
-    url='https://github.com/jiangwen365/pypyodbc',
+    url='https://github.com/pypyodbc/pypyodbc',
     py_modules=['pypyodbc'],
-    long_description="""
-      A Pure Python ctypes ODBC module compatible with PyPy and almost totally same usage as pyodbc
-      """,
+    long_description=
+        "A Pure Python ctypes ODBC module compatible with PyPy and almost"
+        " totally same usage as pyodbc.",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        'Natural Language :: English',
+        'Operating System :: MacOS :: MacOS X',
+        'Operating System :: Microsoft :: Windows',
+        'Operating System :: POSIX',
+        'Operating System :: POSIX :: Linux',
+        'Operating System :: Unix',
     ],
     keywords='Python, Database, Interface, ODBC, PyPy',
     license='MIT',

--- a/test/test_pypyodbc.py
+++ b/test/test_pypyodbc.py
@@ -1,0 +1,26 @@
+"""Unittests for pypyodbc.py."""
+
+import datetime
+import unittest
+import pypyodbc
+
+
+class TestGetType(unittest.TestCase):
+    def test_valid_types(self):
+        # TODO: add more types coverage.
+        cases = (
+            ('boolean', True, ('b',)),
+            ('unicode', 'any string is unicode', ('u',)),
+            ('unicode large 256', 'x' * 256, ('U', 2000)),
+            ('unicode large 2500', 'x' * 2500, ('U', 6000)),
+            ('int', 0, ('i',)),
+            ('long', 2**31, ('l',)),
+            ('long negative', -2**31-1, ('l',)),
+            ('float', 1.1, ('f',)),
+            ('datetime', datetime.datetime(2022, 2, 19), ('dt',)),
+            ('date', datetime.date(2022, 2, 19), ('d',)),
+            ('time', datetime.time(), ('t',)),
+        )
+        for name, input_type, expected in cases:
+            with self.subTest(name=name):
+                self.assertEqual(expected, pypyodbc.get_type(input_type))


### PR DESCRIPTION
Includes a .gitignore file so we do not add unwanted files accidentally.
A very basic unittest so the module can at least be loaded, and a starting point for more unittests.
Clarify the macOS support in the README.
Add more pypi classifier for the project.
Update the repository url to the new home.