### PR TITLE
Refactor deprecated unittest aliases for Python 3 compatibility.

### DIFF
--- a/accesstests.py
+++ b/accesstests.py
@@ -293,11 +293,11 @@ class AccessTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(s varchar(20))")
         self.cursor.execute("insert into t1 values(?)", ("1",))
         row = self.cursor.execute("select * from t1").fetchone()
-        self.assertEquals(row[0], "1")
-        self.assertEquals(row[-1], "1")
+        self.assertEqual(row[0], "1")
+        self.assertEqual(row[-1], "1")
 
     def test_version(self):
-        self.assertEquals(3, len(pypyodbc.version.split('.'))) # 1.3.1 etc.
+        self.assertEqual(3, len(pypyodbc.version.split('.'))) # 1.3.1 etc.
 
     #
     # date, time, datetime
@@ -310,7 +310,7 @@ class AccessTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", (value,))
 
         result = self.cursor.execute("select dt from t1").fetchone()[0]
-        self.assertEquals(value, result)
+        self.assertEqual(value, result)
 
     #
     # ints and floats
@@ -321,28 +321,28 @@ class AccessTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(n int)")
         self.cursor.execute("insert into t1 values (?)", (value,))
         result = self.cursor.execute("select n from t1").fetchone()[0]
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     def test_negative_int(self):
         value = -1
         self.cursor.execute("create table t1(n int)")
         self.cursor.execute("insert into t1 values (?)", (value,))
         result = self.cursor.execute("select n from t1").fetchone()[0]
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     def test_smallint(self):
         value = 32767
         self.cursor.execute("create table t1(n smallint)")
         self.cursor.execute("insert into t1 values (?)", (value,))
         result = self.cursor.execute("select n from t1").fetchone()[0]
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     def test_real(self):
         value = 1234.5
         self.cursor.execute("create table t1(n real)")
         self.cursor.execute("insert into t1 values (?)", (value,))
         result = self.cursor.execute("select n from t1").fetchone()[0]
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     def test_negative_real(self):
         value = -200.5
@@ -356,7 +356,7 @@ class AccessTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(n float)")
         self.cursor.execute("insert into t1 values (?)", (value,))
         result = self.cursor.execute("select n from t1").fetchone()[0]
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     def test_negative_float(self):
         value = -200.5
@@ -440,13 +440,13 @@ class AccessTestCase(unittest.TestCase):
     #
 
     def test_rowcount_delete(self):
-        self.assertEquals(self.cursor.rowcount, -1)
+        self.assertEqual(self.cursor.rowcount, -1)
         self.cursor.execute("create table t1(i int)")
         count = 4
         for i in range(count):
             self.cursor.execute("insert into t1 values (?)", (i,))
         self.cursor.execute("delete from t1")
-        self.assertEquals(self.cursor.rowcount, count)
+        self.assertEqual(self.cursor.rowcount, count)
 
     def test_rowcount_nodata(self):
         """
@@ -459,7 +459,7 @@ class AccessTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(i int)")
         # This is a different code path internally.
         self.cursor.execute("delete from t1")
-        self.assertEquals(self.cursor.rowcount, 0)
+        self.assertEqual(self.cursor.rowcount, 0)
 
     def test_rowcount_select(self):
         """
@@ -474,11 +474,11 @@ class AccessTestCase(unittest.TestCase):
         for i in range(count):
             self.cursor.execute("insert into t1 values (?)", (i,))
         self.cursor.execute("select * from t1")
-        self.assertEquals(self.cursor.rowcount, -1)
+        self.assertEqual(self.cursor.rowcount, -1)
 
         rows = self.cursor.fetchall()
-        self.assertEquals(len(rows), count)
-        self.assertEquals(self.cursor.rowcount, -1)
+        self.assertEqual(len(rows), count)
+        self.assertEqual(self.cursor.rowcount, -1)
 
     def test_rowcount_reset(self):
         "Ensure rowcount is reset to -1"
@@ -487,10 +487,10 @@ class AccessTestCase(unittest.TestCase):
         count = 4
         for i in range(count):
             self.cursor.execute("insert into t1 values (?)", (i,))
-        self.assertEquals(self.cursor.rowcount, 1)
+        self.assertEqual(self.cursor.rowcount, 1)
 
         self.cursor.execute("create table t2(i int)")
-        self.assertEquals(self.cursor.rowcount, -1)
+        self.assertEqual(self.cursor.rowcount, -1)
 
     #
     # Misc
@@ -510,7 +510,7 @@ class AccessTestCase(unittest.TestCase):
         names = [ t[0] for t in self.cursor.description ]
         names.sort()
 
-        self.assertEquals(names, [ "abc", "def" ])
+        self.assertEqual(names, [ "abc", "def" ])
 
         # Put it back so other tests don't fail.
         pypyodbc.lowercase = False
@@ -525,7 +525,7 @@ class AccessTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values(1, 'abc')")
 
         row = self.cursor.execute("select * from t1").fetchone()
-        self.assertEquals(self.cursor.description, row.cursor_description)
+        self.assertEqual(self.cursor.description, row.cursor_description)
         
 
     def test_executemany(self):
@@ -557,7 +557,7 @@ class AccessTestCase(unittest.TestCase):
                    ('error', 'not an int'),
                    (3, 'good') ]
         
-        self.failUnlessRaises(pypyodbc.Error, self.cursor.executemany, "insert into t1(a, b) value (?, ?)", (params))
+        self.assertTrueRaises(pypyodbc.Error, self.cursor.executemany, "insert into t1(a, b) value (?, ?)", (params))
 
         
     def test_row_slicing(self):
@@ -567,13 +567,13 @@ class AccessTestCase(unittest.TestCase):
         row = self.cursor.execute("select * from t1").fetchone()
 
         result = row[:]
-        self.failUnless(result == row)
+        self.assertTrue(result == row)
 
         result = row[:-1]
         self.assertEqual(result, (1,2,3))
 
         result = row[0:4]
-        self.failUnless(result == row)
+        self.assertTrue(result == row)
 
 
     def test_row_repr(self):

--- a/exceltests.py
+++ b/exceltests.py
@@ -60,10 +60,10 @@ class ExcelTestCase(unittest.TestCase):
         # Our second sheet is named Sheet2 and has two columns.  The first has values 10, 20, 30, etc.
 
         rows = self.cursor.execute("select * from [Sheet2$]").fetchall()
-        self.assertEquals(len(rows), 5)
+        self.assertEqual(len(rows), 5)
 
         for index, row in enumerate(rows):
-            self.assertEquals(row['s2num'], float(index + 1) * 10)
+            self.assertEqual(row['s2num'], float(index + 1) * 10)
 
     def test_read_range(self):
         # The second method of reading data is to assign a name to a range of cells and access that as a table.
@@ -71,11 +71,11 @@ class ExcelTestCase(unittest.TestCase):
         # Our first worksheet has a section named Table1.  The first column has values 1, 2, 3, etc.
 
         rows = self.cursor.execute("select * from Table1").fetchall()
-        self.assertEquals(len(rows), 10)
+        self.assertEqual(len(rows), 10)
      
         for index, row in enumerate(rows):
-            self.assertEquals(row['num'], float(index + 1))
-            self.assertEquals(row['val'], chr(ord('a') + index))
+            self.assertEqual(row['num'], float(index + 1))
+            self.assertEqual(row['val'], chr(ord('a') + index))
 
     def test_tables(self):
         # This is useful for figuring out what is available

--- a/sqlservertests.py
+++ b/sqlservertests.py
@@ -531,11 +531,11 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(s varchar(20))")
         self.cursor.execute("insert into t1 values(?)", ("1",))
         row = self.cursor.execute("select * from t1").fetchone()
-        self.assertEquals(row[0], "1")
-        self.assertEquals(row[-1], "1")
+        self.assertEqual(row[0], "1")
+        self.assertEqual(row[-1], "1")
 
     def test_version(self):
-        self.assertEquals(3, len(pypyodbc.version.split('.'))) # 1.3.1 etc.
+        self.assertEqual(3, len(pypyodbc.version.split('.'))) # 1.3.1 etc.
 
     #
     # date, time, datetime
@@ -548,8 +548,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", (value,))
 
         result = self.cursor.execute("select dt from t1").fetchone()[0]
-        self.assertEquals(type(value), datetime)
-        self.assertEquals(value, result)
+        self.assertEqual(type(value), datetime)
+        self.assertEqual(value, result)
 
     def test_datetime_fraction(self):
         # SQL Server supports milliseconds, but Python's datetime supports nanoseconds, so the most granular datetime
@@ -561,8 +561,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", (value,))
      
         result = self.cursor.execute("select dt from t1").fetchone()[0]
-        self.assertEquals(type(value), datetime)
-        self.assertEquals(result, value)
+        self.assertEqual(type(value), datetime)
+        self.assertEqual(result, value)
 
     def test_datetime_fraction_rounded(self):
         # SQL Server supports milliseconds, but Python's datetime supports nanoseconds.  pypyodbc rounds down to what the
@@ -575,8 +575,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", (full,))
      
         result = self.cursor.execute("select dt from t1").fetchone()[0]
-        self.assertEquals(type(result), datetime)
-        self.assertEquals(result, rounded)
+        self.assertEqual(type(result), datetime)
+        self.assertEqual(result, rounded)
 
     def test_date(self):
         ver = self.get_sqlserver_version()
@@ -589,8 +589,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", (value,))
      
         result = self.cursor.execute("select d from t1").fetchone()[0]
-        self.assertEquals(type(value), date)
-        self.assertEquals(value, result)
+        self.assertEqual(type(value), date)
+        self.assertEqual(value, result)
 
     def test_time(self):
         ver = self.get_sqlserver_version()
@@ -607,8 +607,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", (value,))
          
         result = self.cursor.execute("select t from t1").fetchone()[0]
-        self.assertEquals(type(value), time)
-        self.assertEquals(value, result)
+        self.assertEqual(type(value), time)
+        self.assertEqual(value, result)
 
     def test_datetime2(self):
         ver = self.get_sqlserver_version()
@@ -620,8 +620,8 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("insert into t1 values (?)", (value,))
 
         result = self.cursor.execute("select dt from t1").fetchone()[0]
-        self.assertEquals(type(value), datetime)
-        self.assertEquals(value, result)
+        self.assertEqual(type(value), datetime)
+        self.assertEqual(value, result)
 
     #
     # ints and floats
@@ -632,14 +632,14 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(n int)")
         self.cursor.execute("insert into t1 values (?)", (value,))
         result = self.cursor.execute("select n from t1").fetchone()[0]
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     def test_negative_int(self):
         value = -1
         self.cursor.execute("create table t1(n int)")
         self.cursor.execute("insert into t1 values (?)", (value,))
         result = self.cursor.execute("select n from t1").fetchone()[0]
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     def test_bigint(self):
         input = 3000000000
@@ -653,7 +653,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(n float)")
         self.cursor.execute("insert into t1 values (?)", (value,))
         result = self.cursor.execute("select n from t1").fetchone()[0]
-        self.assertEquals(result, value)
+        self.assertEqual(result, value)
 
     def test_negative_float(self):
         value = -200
@@ -680,9 +680,9 @@ class SqlServerTestCase(unittest.TestCase):
               from sysobjects
             """)
         rows = self.cursor.execute("exec proc1").fetchall()
-        self.assertEquals(type(rows), list)
-        self.assertEquals(len(rows), 10) # there has to be at least 10 items in sysobjects
-        self.assertEquals(type(rows[0].refdate), datetime)
+        self.assertEqual(type(rows), list)
+        self.assertEqual(len(rows), 10) # there has to be at least 10 items in sysobjects
+        self.assertEqual(type(rows[0].refdate), datetime)
 
 
     def test_sp_results_from_temp(self):
@@ -706,9 +706,9 @@ class SqlServerTestCase(unittest.TestCase):
         self.assert_(len(self.cursor.description) == 4)
 
         rows = self.cursor.fetchall()
-        self.assertEquals(type(rows), list)
-        self.assertEquals(len(rows), 10) # there has to be at least 10 items in sysobjects
-        self.assertEquals(type(rows[0].refdate), datetime)
+        self.assertEqual(type(rows), list)
+        self.assertEqual(len(rows), 10) # there has to be at least 10 items in sysobjects
+        self.assertEqual(type(rows[0].refdate), datetime)
 
 
     def test_sp_results_from_vartbl(self):
@@ -727,9 +727,9 @@ class SqlServerTestCase(unittest.TestCase):
             """)
         self.cursor.execute("exec proc1")
         rows = self.cursor.fetchall()
-        self.assertEquals(type(rows), list)
-        self.assertEquals(len(rows), 10) # there has to be at least 10 items in sysobjects
-        self.assertEquals(type(rows[0].refdate), datetime)
+        self.assertEqual(type(rows), list)
+        self.assertEqual(len(rows), 10) # there has to be at least 10 items in sysobjects
+        self.assertEqual(type(rows[0].refdate), datetime)
 
     def test_sp_with_dates(self):
         # Reported in the forums that passing two datetimes to a stored procedure doesn't work.
@@ -777,13 +777,13 @@ class SqlServerTestCase(unittest.TestCase):
     #
 
     def test_rowcount_delete(self):
-        self.assertEquals(self.cursor.rowcount, -1)
+        self.assertEqual(self.cursor.rowcount, -1)
         self.cursor.execute("create table t1(i int)")
         count = 4
         for i in range(count):
             self.cursor.execute("insert into t1 values (?)", (i,))
         self.cursor.execute("delete from t1")
-        self.assertEquals(self.cursor.rowcount, count)
+        self.assertEqual(self.cursor.rowcount, count)
 
     def test_rowcount_nodata(self):
         """
@@ -796,7 +796,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(i int)")
         # This is a different code path internally.
         self.cursor.execute("delete from t1")
-        self.assertEquals(self.cursor.rowcount, 0)
+        self.assertEqual(self.cursor.rowcount, 0)
 
     def test_rowcount_select(self):
         """
@@ -811,11 +811,11 @@ class SqlServerTestCase(unittest.TestCase):
         for i in range(count):
             self.cursor.execute("insert into t1 values (?)", (i,))
         self.cursor.execute("select * from t1")
-        self.assertEquals(self.cursor.rowcount, -1)
+        self.assertEqual(self.cursor.rowcount, -1)
 
         rows = self.cursor.fetchall()
-        self.assertEquals(len(rows), count)
-        self.assertEquals(self.cursor.rowcount, -1)
+        self.assertEqual(len(rows), count)
+        self.assertEqual(self.cursor.rowcount, -1)
 
     def test_rowcount_reset(self):
         "Ensure rowcount is reset to -1"
@@ -824,10 +824,10 @@ class SqlServerTestCase(unittest.TestCase):
         count = 4
         for i in range(count):
             self.cursor.execute("insert into t1 values (?)", (i,))
-        self.assertEquals(self.cursor.rowcount, 1)
+        self.assertEqual(self.cursor.rowcount, 1)
 
         self.cursor.execute("create table t2(i int)")
-        self.assertEquals(self.cursor.rowcount, -1)
+        self.assertEqual(self.cursor.rowcount, -1)
 
     #
     # always return Cursor
@@ -841,7 +841,7 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(i int)")
         self.cursor.execute("insert into t1 values (1)")
         v = self.cursor.execute("delete from t1")
-        self.assertEquals(v, self.cursor)
+        self.assertEqual(v, self.cursor)
 
     def test_retcursor_nodata(self):
         """
@@ -853,13 +853,13 @@ class SqlServerTestCase(unittest.TestCase):
         self.cursor.execute("create table t1(i int)")
         # This is a different code path internally.
         v = self.cursor.execute("delete from t1")
-        self.assertEquals(v, self.cursor)
+        self.assertEqual(v, self.cursor)
 
     def test_retcursor_select(self):
         self.cursor.execute("create table t1(i int)")
         self.cursor.execute("insert into t1 values (1)")
         v = self.cursor.execute("select * from t1")
-        self.assertEquals(v, self.cursor)
+        self.assertEqual(v, self.cursor)
 
     #
     # misc
@@ -879,7 +879,7 @@ class SqlServerTestCase(unittest.TestCase):
         names = [ t[0] for t in self.cursor.description ]
         names.sort()
 
-        self.assertEquals(names, [ "abc", "def" ])
+        self.assertEqual(names, [ "abc", "def" ])
 
         # Put it back so other tests don't fail.
         pypyodbc.lowercase = False
@@ -895,7 +895,7 @@ class SqlServerTestCase(unittest.TestCase):
 
         row = self.cursor.execute("select * from t1").fetchone()
 
-        self.assertEquals(self.cursor.description, row.cursor_description)
+        self.assertEqual(self.cursor.description, row.cursor_description)
         
 
     def test_temp_select(self):
@@ -969,7 +969,7 @@ class SqlServerTestCase(unittest.TestCase):
                    ('error', 'not an int'),
                    (3, 'good') ]
         
-        self.failUnlessRaises(pypyodbc.Error, self.cursor.executemany, "insert into t1(a, b) value (?, ?)", params)
+        self.assertTrueRaises(pypyodbc.Error, self.cursor.executemany, "insert into t1(a, b) value (?, ?)", params)
 
         
     def test_row_slicing(self):
@@ -979,13 +979,13 @@ class SqlServerTestCase(unittest.TestCase):
         row = self.cursor.execute("select * from t1").fetchone()
 
         result = row[:]
-        self.failUnless(result == row)
+        self.assertTrue(result == row)
 
         result = row[:-1]
         self.assertEqual(result, (1,2,3))
 
         result = row[0:4]
-        self.failUnless(result == row)
+        self.assertTrue(result == row)
 
 
     def test_row_repr(self):
@@ -1289,8 +1289,8 @@ class SqlServerTestCase(unittest.TestCase):
         cursor = None
 
         rows = self.cursor.execute("select n from t1").fetchall()
-        self.assertEquals(len(rows), 1)
-        self.assertEquals(rows[0][0], 1)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0], 1)
 
 
     def test_context_manager_fail(self):
@@ -1312,7 +1312,7 @@ class SqlServerTestCase(unittest.TestCase):
         cursor = None
 
         count = self.cursor.execute("select count(*) from t1").fetchone()[0]
-        self.assertEquals(count, 0)
+        self.assertEqual(count, 0)
 
 
     def test_cursor_context_manager_success(self):
@@ -1328,8 +1328,8 @@ class SqlServerTestCase(unittest.TestCase):
         cursor = None
 
         rows = self.cursor.execute("select n from t1").fetchall()
-        self.assertEquals(len(rows), 1)
-        self.assertEquals(rows[0][0], 1)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0][0], 1)
 
 
     def test_cursor_context_manager_fail(self):
@@ -1349,7 +1349,7 @@ class SqlServerTestCase(unittest.TestCase):
         cursor = None
 
         count = self.cursor.execute("select count(*) from t1").fetchone()[0]
-        self.assertEquals(count, 0)
+        self.assertEqual(count, 0)
 
 
     def test_untyped_none(self):
@@ -1375,7 +1375,7 @@ class SqlServerTestCase(unittest.TestCase):
                             ''')
         self.cnxn.commit()
         value = self.cursor.execute("select * from func1(?)", ('test',)).fetchone()[0]
-        self.assertEquals(value, 'test')
+        self.assertEqual(value, 'test')
         
     def test_no_fetch(self):
         # Issue 89 with FreeTDS: Multiple selects (or catalog functions that issue selects) without fetches seem to


### PR DESCRIPTION
The deprecated aliases were removed in https://github.com/python/cpython/pull/28268 and reverted back. This might be introduced in future Python versions. Hence fix deprecation warnings.